### PR TITLE
feat(ffi): interface w/ CTable C library from Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 /target
 /resources
+
+output_*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,30 @@
 version = 4
 
 [[package]]
+name = "cc"
+version = "1.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "tpe_pi_rust"
 version = "0.1.0"
+dependencies = [
+ "cc",
+ "libc",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ nyc = []
 chi = []
 
 [dependencies]
+libc = "0.2.0"
+
+[build-dependencies]
+cc = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    cc::Build::new()
+        .file("src/ctable/htmlTable.c")
+        .include("src/ctable")
+        .compile("clibrary");
+
+    println!("cargo:rerun-if-changed=src/ctable/htmlTable.c");
+    println!("cargo:rerun-if-changed=src/ctable/htmlTable.h");
+}

--- a/src/ctable/htmlTable.c
+++ b/src/ctable/htmlTable.c
@@ -1,0 +1,66 @@
+#include "htmlTable.h"
+#include <stdarg.h>
+#include <stdlib.h>
+
+#define TABLE_HEAD "thead"
+#define TABLE_BODY "tbody"
+#define TABLE_HEADING "th"
+#define TABLE_ROW "tr"
+#define TABLE_DATA "td"
+
+struct table {
+	FILE * file;
+	unsigned int columns;
+	
+};
+
+static void addNodes(const char * fatherNode, const char * childNode, htmlTable table, va_list arg);
+
+htmlTable newTable (const char * fileName, unsigned int columns, ...) {
+    errno = 0;
+    FILE * file = fopen(fileName, "w");
+    if ( file == NULL ) {
+	    return NULL;
+    }	    
+    htmlTable table = malloc(sizeof(struct table));
+    if ( errno == ENOMEM ) {
+	    fclose(file);
+	    return NULL;
+    }
+    table->file = file;
+    table->columns = columns;
+    va_list args;
+    va_start(args, columns);
+    fputs("<link href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css\" rel=\"stylesheet\" "
+          "integrity=\"sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3\" "
+          "crossorigin=\"anonymous\">", file);
+    fputs("<html><table class=\"table table-striped table-hover\">", file);
+    fprintf(file, "<%s>", TABLE_HEAD);
+    addNodes(TABLE_ROW, TABLE_HEADING, table, args);
+    fprintf(file, "</%s><%s>", TABLE_HEAD, TABLE_BODY);
+    return table;
+}
+
+void
+addHTMLRow(const htmlTable table, ...) {
+    va_list args;
+    va_start(args, table);
+    addNodes(TABLE_ROW, TABLE_DATA, table, args);
+}
+
+void
+closeHTMLTable(htmlTable table) {
+    fprintf(table->file, "</%s></table></html>", TABLE_BODY);
+    fclose(table->file);
+    free(table);
+}
+
+static void
+addNodes(const char * fatherNode, const char * childNode, htmlTable table, va_list arg) {
+    fprintf(table->file, "<%s>", fatherNode);
+    for (int i = 0; i < table->columns; i++) {
+        fprintf(table->file, "<%s>%s</%s>", childNode, va_arg(arg, char *), childNode);
+    }
+    va_end(arg);
+    fprintf(table->file, "</%s>", fatherNode);
+}

--- a/src/ctable/htmlTable.h
+++ b/src/ctable/htmlTable.h
@@ -1,0 +1,39 @@
+#ifndef __ctable_h_
+#define __ctable_h_
+#include <stdio.h>
+#include <errno.h>
+
+/*
+* htmlTable es un puntero a un struct desconocido. Si bien tiene la forma de un TAD, no 
+* es algo genÃrico ni exclusivamente de backend.
+*/
+typedef struct table * htmlTable;
+
+/*
+ * @returns Puntero a la esructura con lo necesario para agregar columnas a una tabla HTML
+            En caso de error (no se pudo crear el archivo) retorn NULL
+ * @param fileName Nombre del archivo a crear
+ * @param columns Cantidad de columnas que tendría la tabla
+ * @param ...  Título de cada una de las columnas. Debería haber tantos
+ *             strings como columnas se indicaron. En caso de poner más se ignoran
+ *             En caso de poner menos o tipos incorrectos el resultado es impredecible
+ *             (como si a printf se le pasan menos argumentos o tipos incorrectos)
+ *             
+ */
+htmlTable newTable(const char * fileName, unsigned int columns, ...);
+
+
+/*
+ * Agrega una fila a la tabla. Se deben enviar tantos strings como columnas se hayan indicado
+ *             En caso de poner menos o tipos incorrectos el resultado es impredecible
+ *             (como si a printf se le pasan menos argumentos o tipos incorrectos)
+ * 
+*/
+void addHTMLRow(htmlTable table, ...);
+
+/**
+ * Finaliza la tabla, cierra el archivo y libera toda la memoria reservada
+*/ 
+void closeHTMLTable(htmlTable table);
+
+#endif

--- a/src/ctable/mod.rs
+++ b/src/ctable/mod.rs
@@ -1,0 +1,7 @@
+use libc::{c_char, c_uint, c_void};
+
+unsafe extern "C" {
+    pub fn newTable(fileName: *const c_char, columns: c_uint, ...) -> *mut c_void;
+    pub fn addHTMLRow(table: *mut c_void, ...);
+    pub fn closeHTMLTable(table: *mut c_void);
+}


### PR DESCRIPTION
Use CTable to write the output of the queries.

This currently uses quite hefty `unsafe` blocks... which is not ideal. I'll modify this later on to provide safe wrappers over the unsafe C calls, so they can be used from standard safe Rust

TODO: There's a compiler warning on `htmlTable.c` `-Wsign-compare`. I'll see how to silence this later on (since according to the final, the library should not be modified at all...)